### PR TITLE
Field Visit: wire scheduling endpoints, list/profile/contact, and harden snackbar/API

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "express-rate-limit": "^7.1.5",
+        "express-validator": "^7.2.1",
         "google-auth-library": "^10.2.1",
         "googleapis": "^156.0.0",
         "helmet": "^7.1.0",
@@ -3314,6 +3315,28 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-validator/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5175,6 +5198,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/farmer_mobile_app/app/dashboard/tabs/fieldVisit/index.tsx
+++ b/farmer_mobile_app/app/dashboard/tabs/fieldVisit/index.tsx
@@ -214,7 +214,7 @@ const FieldVisitScreen: React.FC = () => {
                 onPress={async () => {
                   // Fetch details by id for description
                   try {
-                    const res = await APIService.getInstance().get(`${ServiceBaseUrl}/soil-testing-scheduling/field-visitors/${item.id}`);
+                    const res = await APIService.getInstance().get(`${AppConfig.apiEndpoints.fieldVisitors}/${item.id}`);
                     const data: Officer = res.data?.data || item;
                     const mapped: Expert = {
                       id: String(data.id),
@@ -316,7 +316,7 @@ const FieldVisitScreen: React.FC = () => {
                   urgency_level: urgency,
                 };
                 // Prefer new namespace if backend exposes it, otherwise fallback to legacy path
-                const contactUrl = `${ServiceBaseUrl}/soil-testing-scheduling/contact-requests`;
+                const contactUrl = AppConfig.apiEndpoints.contactRequest;
                 await APIService.getInstance().post(contactUrl, body, {
                   headers: token ? { Authorization: `Bearer ${token}` } : undefined,
                 });
@@ -571,7 +571,7 @@ const ContactFormInline: React.FC<{ onSubmit: (payload: ContactPayload) => void 
   const validateMobile = (v: string) => {
     const value = v.replace(/\s+/g, '');
     if (!value) return 'Mobile number is required';
-    if (!/^\+?[0-9]{10}$/.test(value)) return 'Enter a valid mobile number (10 digits)';
+  if (!/^\+?[0-9]{10,15}$/.test(value)) return 'Enter a valid mobile number (10-15 digits, may start with +)';
     return '';
   };
   // Address optional; only warn if provided but too short

--- a/farmer_mobile_app/app/index.tsx
+++ b/farmer_mobile_app/app/index.tsx
@@ -16,14 +16,14 @@ const HomeScreen = () => {
   const dispatch = useAppDispatch();
   const auth = useAppSelector(state => state?.auth);
 
-  APIService.initialize(AppConfig.serviceUrls.authenticaion);
+  APIService.initialize(AppConfig.serviceUrls.authentication);
 
   useEffect(() => {
     const initializeAuth = async () => {
       const storedToken = await AsyncStorage.getItem('token');
       setToken(storedToken);
       if (storedToken) {
-        checkAuthToken(dispatch);
+        dispatch(checkAuthToken());
       }
       setLoading(false);
     };

--- a/farmer_mobile_app/app/index.tsx
+++ b/farmer_mobile_app/app/index.tsx
@@ -23,7 +23,7 @@ const HomeScreen = () => {
       const storedToken = await AsyncStorage.getItem('token');
       setToken(storedToken);
       if (storedToken) {
-        dispatch(checkAuthToken());
+        await dispatch(checkAuthToken());
       }
       setLoading(false);
     };

--- a/farmer_mobile_app/config/config.ts
+++ b/farmer_mobile_app/config/config.ts
@@ -25,6 +25,11 @@ export const AppConfig = {
     updateProfile: `${ServiceBaseUrl}/auth/update-profile`,
     uploadProfilePicture: `${ServiceBaseUrl}/auth/upload-profile-picture`,
     locations: `${ServiceBaseUrl}/auth/locations`,
-    warehouse: `${ServiceBaseUrl}/api/v1`,
+  // Harvest Hub endpoints
+  warehouses: `${ServiceBaseUrl}/warehouse`,
+  farmerWarehouseRequests: `${ServiceBaseUrl}/farmer-warehouse/requests`,
+  marketPrices: `${ServiceBaseUrl}/farmer-warehouse/market-prices`,
+  // Field Visit / Soil Testing Scheduling
+  fieldVisitors: `${ServiceBaseUrl}/soil-testing-scheduling/field-visitors`,
   },
 };

--- a/farmer_mobile_app/config/config.ts
+++ b/farmer_mobile_app/config/config.ts
@@ -31,5 +31,6 @@ export const AppConfig = {
   marketPrices: `${ServiceBaseUrl}/farmer-warehouse/market-prices`,
   // Field Visit / Soil Testing Scheduling
   fieldVisitors: `${ServiceBaseUrl}/soil-testing-scheduling/field-visitors`,
+  contactRequest: `${ServiceBaseUrl}/soil-testing-scheduling/contact-requests`,
   },
 };

--- a/farmer_mobile_app/utils/SnackbarUtils.ts
+++ b/farmer_mobile_app/utils/SnackbarUtils.ts
@@ -1,21 +1,25 @@
-import Snackbar from 'react-native-snackbar';
+// Safe dynamic import to work in Expo Go where the native module may be unavailable
+let RN_Snackbar: any = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  RN_Snackbar = require('react-native-snackbar');
+} catch {
+  RN_Snackbar = null;
+}
 
-// Function to show a success snackbar
-export const showSuccessSnackbar = (message: string) => {
-  Snackbar.show({
-    text: message,
-    duration: Snackbar.LENGTH_SHORT, // Options: LENGTH_SHORT, LENGTH_LONG, LENGTH_INDEFINITE
-    backgroundColor: '#4CAF50', // Green for success
-    textColor: '#FFFFFF',
-  });
+const show = (message: string, bg: string) => {
+  if (RN_Snackbar && typeof RN_Snackbar.show === 'function') {
+    RN_Snackbar.show({
+      text: message,
+      duration: RN_Snackbar.LENGTH_SHORT,
+      backgroundColor: bg,
+      textColor: '#FFFFFF',
+    });
+  } else {
+    // Fallback: log to console to avoid crashing in Expo Go
+    console.log('[SNACKBAR]', message);
+  }
 };
 
-// Function to show an error snackbar
-export const showErrorSnackbar = (message: string) => {
-  Snackbar.show({
-    text: message,
-    duration: Snackbar.LENGTH_SHORT,
-    backgroundColor: '#F44336', // Red for errors
-    textColor: '#FFFFFF',
-  });
-};
+export const showSuccessSnackbar = (message: string) => show(message, '#4CAF50');
+export const showErrorSnackbar = (message: string) => show(message, '#F44336');

--- a/farmer_mobile_app/utils/apiService.ts
+++ b/farmer_mobile_app/utils/apiService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ServiceBaseUrl } from '@/config/config';
 
 export class APIService {
   private static _instance: AxiosInstance;
@@ -83,7 +84,8 @@ export class APIService {
   // Get the shared axios instance
   public static getInstance(): AxiosInstance {
     if (!APIService._instance) {
-      throw new Error('APIService not initialized. Call initialize() first.');
+      // Fallback: auto-initialize with default base URL
+      APIService.initialize(ServiceBaseUrl);
     }
     return APIService._instance;
   }

--- a/farmer_mobile_app/utils/harvestHubApi.ts
+++ b/farmer_mobile_app/utils/harvestHubApi.ts
@@ -1,19 +1,26 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { AppConfig } from '@/config/config';
+import { AppConfig, ServiceBaseUrl } from '@/config/config';
 import { APIService } from '@/utils/apiService';
 
-// For now, reuse the global Axios instance and pass full URLs built from AppConfig
-const api = APIService.getInstance();
+// Ensure we always have an initialized API instance at call time
+function getApi() {
+  try {
+    return APIService.getInstance();
+  } catch {
+    APIService.initialize(ServiceBaseUrl);
+    return APIService.getInstance();
+  }
+}
 
 export const fetchWarehouses = async (page = 1, limit = 10) => {
-  const url = `${AppConfig.serviceUrls.warehouse}/warehouse`;
-  const res = await api.get(url, { params: { page, limit } });
+  const url = AppConfig.apiEndpoints.warehouses;
+  const res = await getApi().get(url, { params: { page, limit } });
   return res.data;
 };
 
 export const fetchWarehouseById = async (id: number | string) => {
-  const url = `${AppConfig.serviceUrls.warehouse}/warehouse/${id}`;
-  const res = await api.get(url);
+  const url = `${AppConfig.apiEndpoints.warehouses}/${id}`;
+  const res = await getApi().get(url);
   return res.data;
 };
 
@@ -25,15 +32,15 @@ export const createStorageRequest = async (payload: {
   storage_duration_days: number;
   storage_requirements?: string;
 }) => {
-  const url = `${AppConfig.serviceUrls.warehouse}/farmer-warehouse/requests`;
+  const url = AppConfig.apiEndpoints.farmerWarehouseRequests;
   const token = await AsyncStorage.getItem('token');
   const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-  const res = await api.post(url, payload, { headers });
+  const res = await getApi().post(url, payload, { headers });
   return res.data;
 };
 
 export const fetchMarketPrices = async () => {
-  const url = `${AppConfig.serviceUrls.warehouse}/farmer-warehouse/market-prices`;
-  const res = await api.get(url);
+  const url = AppConfig.apiEndpoints.marketPrices;
+  const res = await getApi().get(url);
   return res.data;
 };


### PR DESCRIPTION
# PR: Field Visit — integrate Soil Testing Scheduling API

## Title
Field Visit: wire scheduling endpoints, list/profile/contact, and harden snackbar/API

## Summary
- Connect Field Visit to soil-testing-scheduling service (list, detail, contact).  
- Add pagination and smooth UI transitions.  
- Prevent Expo Go snackbar crash; ensure API is always initialized. [Unverified]

## Changes

### Config
- Add `AppConfig.apiEndpoints.fieldVisitors = /soil-testing-scheduling/field-visitors`.

### API / Infra
- Auto-init `APIService` with `ServiceBaseUrl` fallback to avoid “not initialized.”

### Screen
- **List:** `GET /soil-testing-scheduling/field-visitors?page=&limit=&specialization=`  
- **Detail:** `GET /soil-testing-scheduling/field-visitors/:id` with graceful fallback  
- **Contact:** `POST /soil-testing-scheduling/contact-requests`
- Fixed `Expert` type typo (`avatarUrl`).

### Utilities
- `SnackbarUtils`: dynamic `require` + console fallback to avoid `LENGTH_*` null in Expo Go.

## Testing
- Verify list loads by category with page/limit.  
- Open profile; fallback path works if detail fails.  
- Submit contact; success snackbar and confirmation view.  
- No crashes in Expo Go. [Unverified]

## Notes
- If contact endpoint differs on backend, update accordingly.  
- Scheduling `POST` (schedules) will be wired when date/time/location UX is finalized.
